### PR TITLE
Update to Events Section

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -84,7 +84,7 @@ body {
     right: -200px;
     bottom: 0;
     width: 280px;
-    z-index: 1000000;  
+    z-index: 1000000;
     display: none;
 }
 
@@ -329,8 +329,8 @@ body {
 }
 
 .banner-bottom .chunk {
-    width: 0; 
-    height: 0; 
+    width: 0;
+    height: 0;
     border-right: 20px solid white;
     border-left: 20px solid white;
     border-top: 20px solid transparent;
@@ -387,6 +387,10 @@ body {
 
 .join {
     width: 100%;
+}
+
+.events-text {
+    text-align: center;
 }
 
 .about, .info, .schedule, .events, .projects, .partners, .resources, .contact {
@@ -625,7 +629,7 @@ section .title:after {
 }
 
 .resource-col {
-    text-align:center; 
+    text-align:center;
 }
 
 .col:first-child { margin-left: 0; }
@@ -776,12 +780,12 @@ section .title:after {
 
 .contact-details a {
     text-decoration: none;
-    color: #7a7a7a; 
+    color: #7a7a7a;
 }
 
 .contact-details a:hover {
     text-decoration: none;
-    color: #ec0565; 
+    color: #ec0565;
 }
 
 .sponsors {
@@ -802,7 +806,7 @@ section .title:after {
 .flip {
     background: #efefef;
 }
-    
+
 @media only screen and (max-width: 900px) {
     #header nav {
         display: none;
@@ -961,7 +965,7 @@ section .title:after {
     margin-right: 0 !important;
 }
 
-.row-flex, .row-flex > div[class*='col-'] {  
+.row-flex, .row-flex > div[class*='col-'] {
     display: -webkit-box;
     display: -moz-box;
     display: -ms-flexbox;

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 				</div>
 			</div>
 				<p>
-					Empower Hack have launched a series of hackathons this month to create open source solutions on health challenges of refugees women and girls. The hackathons will take place in Ghana, London and Amsterdam over a course of 2-3 day events.
+					Empower Hack have launched a series of hackathons this month to create open source software solutions on health challenges of refugees women and girls. The hackathons will take place in Ghana, London and Amsterdam over a course of 2-3 day events.
 				</p>
 				<p>
 					Medical Professionals, Humanitarian Workers, Marketers, Software Developers, User Experience Designers and Researchers will all come together in each city/country in a new kind of hackathon that is focused on inclusive design, sustainability and partnerships.

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 			 	</ul>
 			</div>
 		</div>
-		<header id="header"> 
+		<header id="header">
 			<span class="header-title">EMPOWERHACK</span>
 			<nav>
 			 	<a href="#about">About</a>
@@ -68,6 +68,48 @@
 					EmpowerHack is a collective that brings creates sustainable design for women and girls in humanitarian contexts. Bridging the gap between technology, design, and NGOs to address key challenges, Empower Hack galvanises volunteers to create code that crosses borders.<br /><br />
 					Despite up to 80% of world’s refugees being women and children, the problems faced by them are never at the forefront. EmpowerHack was born to change just that by taking collaborative design to scale. Female refugees are among the most vulnerable, facing sexual violence, coercion, forced and early marriage, social isolation, and a lack of access to gender-specific health care and education.<br />
 					<a class="button-main" href="https://www.facebook.com/events/1551499561839805/" target="_blank">Join our next event</a>
+				</div>
+			</div>
+		</section>
+		<section class="events flip" id="events">
+			<span class="title">Events</span>
+			<div class="columns group with-button">
+				<div class="col-xs-12 col-md-8 col-md-offset-2 content">
+					<div id="test">
+					<div class="events-text">
+					<span class="small-title">Global Refugee Health Hackathon April 2016</span><br />
+				</div>
+				<div class="col-md-4 events-text">
+					<h2>Ghana</h2>
+					<h4>1st April</h4>
+				</div>
+				<div class="col-md-4 events-text">
+					<h2>London</h2>
+					<h4>8th - 10th April</h4>
+				</div>
+				<div class="col-md-4 events-text">
+					<h2>Amsterdam</h2>
+					<h4>22nd - 24th April</h4>
+				</div>
+			</div>
+				<p>
+					Empower Hack have launched a series of hackathons this month to create open source solutions on health challenges of refugees women and girls. The hackathons will take place in Ghana, London and Amsterdam over a course of 2-3 day events.
+				</p>
+				<p>
+					Medical Professionals, Humanitarian Workers, Marketers, Software Developers, User Experience Designers and Researchers will all come together in each city/country in a new kind of hackathon that is focused on inclusive design, sustainability and partnerships.
+				</p>
+				<p>
+					Contact us at <a href="mailto:empowerhack@gmail.com">empowerhack@gmail.com</a> if you are interested in hosting one in your city, are an NGO with a challenge, or a technology/hackathon partner with an existing project you want to build on at this event.
+				</p>
+					<div class="col-xs-12 col-md-4 button-wrap">
+						<a class="button small-text" href="https://www.facebook.com/events/1551499561839805/" target="_blank">Get Updates</a>
+					</div>
+					<div class="col-xs-12 col-md-4 button-wrap">
+						<a class="button small-text" href="mailto:empowerhack@gmail.com" target="_blank">Host a Hack in your city</a>
+					</div>
+					<div class="col-xs-12 col-md-4 button-wrap">
+						<a class="button small-text" href="mailto:empowerhack@gmail.com" target="_blank">Submit a Design Challenge</a>
+					</div>
 				</div>
 			</div>
 		</section>
@@ -140,10 +182,10 @@
 					<br /><br />
 					<a href="https://www.youtube.com/watch?v=LmJOpOwRULs" target="_blank" style="float: left">Video Demo</a>
 					<a href="https://github.com/empowerhack/HealthMate" target="_blank" style="float: right">GitHub</a><br />
-					
+
 				</div>
 				<div class="col span_1_of_2 project">
-					<span class="team-name">E/MOTION</span><br />is a mobile app that invites refugee women to share how they feel daily with their responses being added as coloured elements to a visual map created based on the emotions of all other women in the communities at camps and cities who use the app. They can then explore the map or choose to chat with one other woman they feel more connected to. The software creates a safe space for women to express themselves emotionally and enables them to connect and support each other anonymously. It creates trust in emotional wellbeing by balancing security, service delivery and anonymity for increased safety and better care.  
+					<span class="team-name">E/MOTION</span><br />is a mobile app that invites refugee women to share how they feel daily with their responses being added as coloured elements to a visual map created based on the emotions of all other women in the communities at camps and cities who use the app. They can then explore the map or choose to chat with one other woman they feel more connected to. The software creates a safe space for women to express themselves emotionally and enables them to connect and support each other anonymously. It creates trust in emotional wellbeing by balancing security, service delivery and anonymity for increased safety and better care.
 					<br /><br />
 					<a href="https://www.youtube.com/watch?v=3Ezq2ZvVFiA" target="_blank" style="float: left">Video Demo</a>
 					<a href="https://github.com/empowerhack/Emotions" target="_blank" style="float: right">GitHub</a><br />
@@ -165,7 +207,7 @@
 					is a small bracelet that helps refugee families stay connected. It is a small beacon device, in the form of a bracelet, that is paired with a mobile phone. Once the button on the bracelet is pressed the GPS location is sent via an encrypted SMS to a server that converts it to a address and sends it to the paired mobile device.<br /><br />
 					<a href="https://www.youtube.com/watch?v=eLZdipIv_zc" target="_blank" style="float: left">Video Demo</a>
 					<a href="https://github.com/empowerhack/Beacon" target="_blank" style="float: right">GitHub</a><br />
-					
+
 				</div>
 			</div>
 
@@ -188,24 +230,6 @@
 					is a platform for skills exchange that changes refugee lives. It connects refugees with each other and to their host community. Users can share skills and offer services for free. This will help to keep them busy, make new connections, hone their skills and increase employability whilst tackling frustration and isolation.<br /><br />
 					<a href="https://www.youtube.com/watch?v=-YBp0hfACjA" target="_blank" style="float: left">Video Demo</a>
 					<a href="https://github.com/empowerhack/HelpAndShare" target="_blank" style="float: right">GitHub</a><br />
-				</div>
-			</div>
-		</section>
-		<section class="events flip" id="events">
-			<span class="title">Events</span>
-			<div class="columns group with-button">
-				<div class="col-xs-12 col-md-8 col-md-offset-2 content">
-					<span class="small-title">Global Refugee Health Hackathon</span><br />
-					Empower Hack will be launching a series of hackathons in April 2016 creating solutions on health challenges of refugees in Oxford, London and Amsterdam.  We’re inviting participants and partners to build more sustainable humanitarian health technologies. 2-3 day events to be hosted in partner cities between April 8-17th. Contact us at empowerhack@gmail.com if you are interested in hosting one in your city, are an NGO with a challenge, or a technology/hackathon partner with an existing project you want to build on at this event.<br />
-					<div class="col-xs-12 col-md-4 button-wrap">
-						<a class="button small-text" href="https://www.facebook.com/events/1551499561839805/" target="_blank">Get Updates</a>
-					</div> 
-					<div class="col-xs-12 col-md-4 button-wrap">
-						<a class="button small-text" href="mailto:empowerhack@gmail.com" target="_blank">Host a Hack in your city</a>
-					</div>
-					<div class="col-xs-12 col-md-4 button-wrap">
-						<a class="button small-text" href="mailto:empowerhack@gmail.com" target="_blank">Submit a Design Challenge</a>
-					</div>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
@empowerhack/website 
#### Changes made
- Written copy updated to reflect the changes in hackathon cities, dates and aim.
- Events section moved up to be placed underneath the `About` section to bring awareness to hackathons to all visitors
#### Style Changes
- Subtitle now centred
- Cities/Countries and dates now separate from main text and in own columns

![image](https://cloud.githubusercontent.com/assets/11095605/14364074/17f2f88c-fcff-11e5-933f-20d40d5bf7c1.png)

Re-arrangement of navbar to reflect this change will made in another PR
